### PR TITLE
ABRO-20492: remove unsupported api calls on Android, failing debug checks

### DIFF
--- a/api-test-extension/src/tests/content_settings.js
+++ b/api-test-extension/src/tests/content_settings.js
@@ -66,6 +66,9 @@ var content_settings_test = new TestSet()
     .require("[Property Exists] cookies", methodExists(chrome.contentSettings, 'cookies'), { hideOnSuccess: true })
     .require("[Property Set] cookies", methodCall(chrome.contentSettings.cookies, 'set', detailsBlock, () => {}))
 
+    .require("[Property Exists] images", methodExists(chrome.contentSettings, 'images'), { hideOnSuccess: true })
+    .suggest("[Property Set] images {Unsupported on Android}", () => "Test disabled")
+
     .require("[Property Exists] javascript",
         methodExists(chrome.contentSettings, 'javascript'), { hideOnSuccess: true })
     .require("[Property Set] javascript",
@@ -73,6 +76,9 @@ var content_settings_test = new TestSet()
 
     .require("[Property Exists] location", methodExists(chrome.contentSettings, 'location'), { hideOnSuccess: true })
     .require("[Property Set] location", methodCall(chrome.contentSettings.location, 'set', detailsBlock, () => {}))
+
+    .require("[Property Exists] plugins", methodExists(chrome.contentSettings, 'plugins'), { hideOnSuccess: true })
+    .suggest("[Property Set] plugins {Unsupported on Android}", () => "Test disabled")
 
     .require("[Property Exists] popups", methodExists(chrome.contentSettings, 'popups'), { hideOnSuccess: true })
     .require("[Property Set] popups", methodCall(chrome.contentSettings.popups, 'set', detailsBlock, () => {}))
@@ -90,6 +96,9 @@ var content_settings_test = new TestSet()
             setting: 'ask'
         }, () => {}))
 
+    .require("[Property Exists] mouselock", methodExists(chrome.contentSettings, 'mouselock'), { hideOnSuccess: true })
+    .suggest("[Property Set] mouselock {Unsupported on Android}", () => "Test disabled")
+
     .require("[Property Exists] microphone",
         methodExists(chrome.contentSettings, 'microphone'), { hideOnSuccess: true })
     .require("[Property Set] microphone",
@@ -97,6 +106,10 @@ var content_settings_test = new TestSet()
 
     .require("[Property Exists] camera", methodExists(chrome.contentSettings, 'camera'), { hideOnSuccess: true })
     .require("[Property Set] camera", methodCall(chrome.contentSettings.camera, 'set', detailsBlock, () => {}))
+
+    .require("[Property Exists] unsandboxedPlugins",
+        methodExists(chrome.contentSettings, 'unsandboxedPlugins'), { hideOnSuccess: true })
+    .suggest("[Property Set] unsandboxedPlugins {Unsupported on Android}", () => "Test disabled")
 
     .require("[Property Exists] automaticDownloads",
         methodExists(chrome.contentSettings, 'automaticDownloads'), { hideOnSuccess: true })

--- a/api-test-extension/src/tests/content_settings.js
+++ b/api-test-extension/src/tests/content_settings.js
@@ -30,8 +30,8 @@ let settingsCheckConvolution = (prev, curr) => {
 };
 
 let propertyNames = [
-    'cookies', 'images', 'javascript', 'location', 'plugins', 'popups', 'notifications',
-    'fullscreen', 'mouselock', 'microphone', 'camera', 'unsandboxedPlugins', 'automaticDownloads'
+    'cookies', 'javascript', 'location', 'popups', 'notifications',
+    'fullscreen', 'microphone', 'camera', 'automaticDownloads'
 ];
 
 let defaultProperties = [];
@@ -66,9 +66,6 @@ var content_settings_test = new TestSet()
     .require("[Property Exists] cookies", methodExists(chrome.contentSettings, 'cookies'), { hideOnSuccess: true })
     .require("[Property Set] cookies", methodCall(chrome.contentSettings.cookies, 'set', detailsBlock, () => {}))
 
-    .require("[Property Exists] images", methodExists(chrome.contentSettings, 'images'), { hideOnSuccess: true })
-    .require("[Property Set] images", methodCall(chrome.contentSettings.images, 'set', detailsBlock, () => {}))
-
     .require("[Property Exists] javascript",
         methodExists(chrome.contentSettings, 'javascript'), { hideOnSuccess: true })
     .require("[Property Set] javascript",
@@ -76,9 +73,6 @@ var content_settings_test = new TestSet()
 
     .require("[Property Exists] location", methodExists(chrome.contentSettings, 'location'), { hideOnSuccess: true })
     .require("[Property Set] location", methodCall(chrome.contentSettings.location, 'set', detailsBlock, () => {}))
-
-    .require("[Property Exists] plugins", methodExists(chrome.contentSettings, 'plugins'), { hideOnSuccess: true })
-    .require("[Property Set] plugins", methodCall(chrome.contentSettings.plugins, 'set', detailsBlock, () => {}))
 
     .require("[Property Exists] popups", methodExists(chrome.contentSettings, 'popups'), { hideOnSuccess: true })
     .require("[Property Set] popups", methodCall(chrome.contentSettings.popups, 'set', detailsBlock, () => {}))
@@ -96,9 +90,6 @@ var content_settings_test = new TestSet()
             setting: 'ask'
         }, () => {}))
 
-    .require("[Property Exists] mouselock", methodExists(chrome.contentSettings, 'mouselock'), { hideOnSuccess: true })
-    .require("[Property Set] mouselock", methodCall(chrome.contentSettings.mouselock, 'set', detailsBlock, () => {}))
-
     .require("[Property Exists] microphone",
         methodExists(chrome.contentSettings, 'microphone'), { hideOnSuccess: true })
     .require("[Property Set] microphone",
@@ -106,11 +97,6 @@ var content_settings_test = new TestSet()
 
     .require("[Property Exists] camera", methodExists(chrome.contentSettings, 'camera'), { hideOnSuccess: true })
     .require("[Property Set] camera", methodCall(chrome.contentSettings.camera, 'set', detailsBlock, () => {}))
-
-    .require("[Property Exists] unsandboxedPlugins",
-        methodExists(chrome.contentSettings, 'unsandboxedPlugins'), { hideOnSuccess: true })
-    .require("[Property Set] unsandboxedPlugins",
-        methodCall(chrome.contentSettings.unsandboxedPlugins, 'set', detailsBlock, () => {}))
 
     .require("[Property Exists] automaticDownloads",
         methodExists(chrome.contentSettings, 'automaticDownloads'), { hideOnSuccess: true })

--- a/api-test-extension/src/tests/content_settings.js
+++ b/api-test-extension/src/tests/content_settings.js
@@ -66,7 +66,7 @@ var content_settings_test = new TestSet()
     .require("[Property Exists] cookies", methodExists(chrome.contentSettings, 'cookies'), { hideOnSuccess: true })
     .require("[Property Set] cookies", methodCall(chrome.contentSettings.cookies, 'set', detailsBlock, () => {}))
 
-    .require("[Property Exists] images", methodExists(chrome.contentSettings, 'images'), { hideOnSuccess: true })
+    .suggest("[Property Exists] images", methodExists(chrome.contentSettings, 'images'), { hideOnSuccess: true })
     .suggest("[Property Set] images {Unsupported on Android}", () => "Test disabled")
 
     .require("[Property Exists] javascript",
@@ -77,7 +77,7 @@ var content_settings_test = new TestSet()
     .require("[Property Exists] location", methodExists(chrome.contentSettings, 'location'), { hideOnSuccess: true })
     .require("[Property Set] location", methodCall(chrome.contentSettings.location, 'set', detailsBlock, () => {}))
 
-    .require("[Property Exists] plugins", methodExists(chrome.contentSettings, 'plugins'), { hideOnSuccess: true })
+    .suggest("[Property Exists] plugins", methodExists(chrome.contentSettings, 'plugins'), { hideOnSuccess: true })
     .suggest("[Property Set] plugins {Unsupported on Android}", () => "Test disabled")
 
     .require("[Property Exists] popups", methodExists(chrome.contentSettings, 'popups'), { hideOnSuccess: true })
@@ -96,7 +96,7 @@ var content_settings_test = new TestSet()
             setting: 'ask'
         }, () => {}))
 
-    .require("[Property Exists] mouselock", methodExists(chrome.contentSettings, 'mouselock'), { hideOnSuccess: true })
+    .suggest("[Property Exists] mouselock", methodExists(chrome.contentSettings, 'mouselock'), { hideOnSuccess: true })
     .suggest("[Property Set] mouselock {Unsupported on Android}", () => "Test disabled")
 
     .require("[Property Exists] microphone",
@@ -107,7 +107,7 @@ var content_settings_test = new TestSet()
     .require("[Property Exists] camera", methodExists(chrome.contentSettings, 'camera'), { hideOnSuccess: true })
     .require("[Property Set] camera", methodCall(chrome.contentSettings.camera, 'set', detailsBlock, () => {}))
 
-    .require("[Property Exists] unsandboxedPlugins",
+    .suggest("[Property Exists] unsandboxedPlugins",
         methodExists(chrome.contentSettings, 'unsandboxedPlugins'), { hideOnSuccess: true })
     .suggest("[Property Set] unsandboxedPlugins {Unsupported on Android}", () => "Test disabled")
 

--- a/api-test-extension/src/tests/privacy.js
+++ b/api-test-extension/src/tests/privacy.js
@@ -73,12 +73,6 @@ var privacy_test = new TestSet()
         chrome.privacy.services.searchSuggestEnabled.get({}, () => resolve(''));
     }), { async: true })
 
-    .require("[Property Exists] services.spellingServiceEnabled",
-        methodExists(chrome.privacy.services, 'spellingServiceEnabled'), { hideOnSuccess: true })
-    .require("[Property Get] services.spellingServiceEnabled", () => new Promise((resolve, reject) => {
-        chrome.privacy.services.spellingServiceEnabled.get({}, () => resolve(''));
-    }), { async: true })
-
     .require("[Property Exists] services.translationServiceEnabled",
         methodExists(chrome.privacy.services, 'translationServiceEnabled'), { hideOnSuccess: true })
     .require("[Property Get] services.translationServiceEnabled", () => new Promise((resolve, reject) => {

--- a/api-test-extension/src/tests/privacy.js
+++ b/api-test-extension/src/tests/privacy.js
@@ -73,7 +73,7 @@ var privacy_test = new TestSet()
         chrome.privacy.services.searchSuggestEnabled.get({}, () => resolve(''));
     }), { async: true })
 
-    .require("[Property Exists] services.spellingServiceEnabled",
+    .suggest("[Property Exists] services.spellingServiceEnabled",
         methodExists(chrome.privacy.services, 'spellingServiceEnabled'), { hideOnSuccess: true })
     .suggest("[Property Get] services.spellingServiceEnabled {Unsupported on Android}", () => "Test disabled")
 

--- a/api-test-extension/src/tests/privacy.js
+++ b/api-test-extension/src/tests/privacy.js
@@ -73,6 +73,10 @@ var privacy_test = new TestSet()
         chrome.privacy.services.searchSuggestEnabled.get({}, () => resolve(''));
     }), { async: true })
 
+    .require("[Property Exists] services.spellingServiceEnabled",
+        methodExists(chrome.privacy.services, 'spellingServiceEnabled'), { hideOnSuccess: true })
+    .suggest("[Property Get] services.spellingServiceEnabled {Unsupported on Android}", () => "Test disabled")
+
     .require("[Property Exists] services.translationServiceEnabled",
         methodExists(chrome.privacy.services, 'translationServiceEnabled'), { hideOnSuccess: true })
     .require("[Property Get] services.translationServiceEnabled", () => new Promise((resolve, reject) => {


### PR DESCRIPTION
These content settings are not available on Android and fail on assertions in debug build: images, plugins, mouselock and unsandboxedPlugins
Spelling service is excluded from Android version and the corresponding preference is also missing.